### PR TITLE
added CF override for the metadata bug in ATL19 in crs_txt

### DIFF
--- a/hoss/hoss_config.json
+++ b/hoss/hoss_config.json
@@ -262,6 +262,20 @@
     {
       "Applicability": {
         "Mission": "ICESat2",
+        "ShortNamePath": "ATL19",
+        "Variable_Pattern": "/north_polar/crs"
+      },
+      "Attributes": [
+        {
+          "Name": "crs_wkt",
+          "Value": "PROJCS[\"NSIDC Sea Ice Polar Stereographic North\",GEOGCS[\"Unspecified datum based upon the Hughes 1980 ellipsoid\",DATUM[\"Not_specified_based_on_Hughes_1980_ellipsoid\",SPHEROID[\"Hughes 1980\",6378273,298.279411123061,AUTHORITY[\"EPSG\",\"7058\"]],AUTHORITY[\"EPSG\",\"6054\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4054\"]],PROJECTION[\"Polar_Stereographic\"],PARAMETER[\"latitude_of_origin\",70],PARAMETER[\"central_meridian\",-45],PARAMETER[\"scale_factor\",1],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"X\",EAST],AXIS[\"Y\",NORTH],AUTHORITY[\"EPSG\",\"3411\"]]"
+        }
+      ],
+      "_Description": "Remove leading slash in ATL19 for crs_wkt attribute"
+    },
+    {
+      "Applicability": {
+        "Mission": "ICESat2",
         "ShortNamePath": "ATL20",
         "Variable_Pattern": "/daily/day\\d{2}/.+"
       },


### PR DESCRIPTION
## Description

A short description of the changes in this PR.

## Jira Issue ID
DAS-2106

## Local Test Steps
- Setup to run harmony in a box
- Git clone the hoss repo and mask fill repo
- Build the image
- restart harmony services
- Test this url and make sure it succeeds
http://localhost:3000/C1260128940-EEDTEST/ogc-api-coverages/1.0.0/collections/north_polar%2Fice_conc_albm,mid_latitude%2Fice_conc_albm,south_polar%2Fice_conc_albm/coverage/rangeset?forceAsync=true&subset=lat(-78.2%3A82.7)&subset=lon(-101.4%3A72.9)&granuleId=G1260128994-EEDTEST&maxResults=1

## PR Acceptance Checklist
* [X ] Jira ticket acceptance criteria met.
* [ ] `CHANGELOG.md` updated to include high level summary of PR changes.
* [ ] `VERSION` updated if publishing a release.
* [ ] Tests added/updated and passing.
* [ ] Documentation updated (if needed).
